### PR TITLE
Stats in the card now round

### DIFF
--- a/src/components/PokemonCardHorizontal.tsx
+++ b/src/components/PokemonCardHorizontal.tsx
@@ -334,7 +334,7 @@ export default function PokemonCardHorizontal({
                         </td>
                         {safeKeys(partyMon.getBaseStats()).map((k) => (
                             <td key={k} className="text-center">
-                                {partyMon.getStats()[k]}
+                                {Math.round(partyMon.getStats()[k])}
                             </td>
                         ))}
                     </tr>


### PR DESCRIPTION
Only affects the UI, no change to the backing stat value.

<img width="521" height="404" alt="image" src="https://github.com/user-attachments/assets/6dd0c324-91ef-4418-b1aa-ca4fe703bc30" />
On live this is 171.6